### PR TITLE
Revamp activity display

### DIFF
--- a/src/entrypoints/DatoBlamePage.tsx
+++ b/src/entrypoints/DatoBlamePage.tsx
@@ -9,12 +9,23 @@ interface CollaboratorInfo {
   name: string;
   role: string;
   lastAccess: string | null;
-  lastUpdate?: { recordId: string; occurredAt: string };
-  lastPublish?: { recordId: string; occurredAt: string; action: string };
+}
+
+interface UpdateInfo {
+  recordId: string;
+  occurredAt: string;
+}
+
+interface PublishInfo {
+  recordId: string;
+  occurredAt: string;
+  action: string;
 }
 
 export default function DatoBlamePage({ ctx }: { ctx: RenderPageCtx }) {
   const [collaborators, setCollaborators] = useState<CollaboratorInfo[] | null>(null);
+  const [recentUpdates, setRecentUpdates] = useState<UpdateInfo[]>([]);
+  const [recentPublishes, setRecentPublishes] = useState<PublishInfo[]>([]);
 
   useEffect(() => {
     async function load() {
@@ -24,40 +35,67 @@ export default function DatoBlamePage({ ctx }: { ctx: RenderPageCtx }) {
       }
 
       const client = buildClient({ apiToken: ctx.currentUserAccessToken });
+
+      const itemTypes = await client.itemTypes.list();
+
+      const updatedItemsArrays = await Promise.all(
+        itemTypes.map((type) =>
+          client.items.list({
+            filter: { type: type.id },
+            order_by: '_updated_at_DESC',
+            page: { limit: 10 },
+            version: 'current',
+          })
+        )
+      );
+
+      const allUpdatedItems = updatedItemsArrays.flat();
+      allUpdatedItems.sort(
+        (a, b) =>
+          new Date(b.meta.updated_at).getTime() -
+          new Date(a.meta.updated_at).getTime()
+      );
+
+      setRecentUpdates(
+        allUpdatedItems.slice(0, 10).map((item) => ({
+          recordId: String(item.id),
+          occurredAt: item.meta.updated_at,
+        }))
+      );
+
+      const publishedItemsArrays = await Promise.all(
+        itemTypes.map((type) =>
+          client.items.list({
+            filter: { type: type.id },
+            order_by: '_updated_at_DESC',
+            page: { limit: 10 },
+            version: 'current',
+          })
+        )
+      );
+
+      const publishCandidates = publishedItemsArrays
+        .flat()
+        .filter((item) => item.meta.first_published_at);
+
+      publishCandidates.sort(
+        (a, b) =>
+          new Date(b.meta.updated_at).getTime() -
+          new Date(a.meta.updated_at).getTime()
+      );
+
+      setRecentPublishes(
+        publishCandidates.slice(0, 10).map((item) => ({
+          recordId: String(item.id),
+          occurredAt: item.meta.updated_at,
+          action: item.meta.published_at ? 'publish' : 'unpublish',
+        }))
+      );
+
       const users = await client.users.list();
 
       const infos: CollaboratorInfo[] = await Promise.all(
         users.map(async (user) => {
-          let lastUpdate;
-          let lastPublish;
-          try {
-            const updateEvents = await client.auditLogEvents.query({
-              filter: `actor.id = '${user.id}' AND action_name = 'update' AND request.path ~ '/items/'`,
-            });
-            if (updateEvents.length > 0) {
-              lastUpdate = {
-                recordId: updateEvents[0].request.path.split('/').pop() || '',
-                occurredAt: updateEvents[0].meta.occurred_at,
-              };
-            }
-          } catch {
-            // ignore
-          }
-          try {
-            const publishEvents = await client.auditLogEvents.query({
-              filter: `actor.id = '${user.id}' AND action_name IN ('publish', 'unpublish') AND request.path ~ '/items/'`,
-            });
-            if (publishEvents.length > 0) {
-              lastPublish = {
-                recordId: publishEvents[0].request.path.split('/').pop() || '',
-                occurredAt: publishEvents[0].meta.occurred_at,
-                action: publishEvents[0].action_name,
-              };
-            }
-          } catch {
-            // ignore
-          }
-
           let roleName = '';
           if (user.role) {
             try {
@@ -73,8 +111,6 @@ export default function DatoBlamePage({ ctx }: { ctx: RenderPageCtx }) {
             name: user.full_name || user.email,
             role: roleName,
             lastAccess: user.meta?.last_access || null,
-            lastUpdate,
-            lastPublish,
           } as CollaboratorInfo;
         })
       );
@@ -93,38 +129,50 @@ export default function DatoBlamePage({ ctx }: { ctx: RenderPageCtx }) {
 
   return (
     <Canvas ctx={ctx}>
-      <table className={s.table}>
-        <thead>
-          <tr>
-            <th>Role</th>
-            <th>Name</th>
-            <th>Last login</th>
-            <th>Last updated record</th>
-            <th>Last publish/unpublish</th>
-          </tr>
-        </thead>
-        <tbody>
-          {collaborators.map((c) => (
-            <tr key={c.id}>
-              <td>{c.role}</td>
-              <td>{c.name}</td>
-              <td>{c.lastAccess ? new Date(c.lastAccess).toLocaleString() : 'Never'}</td>
-              <td>
-                {c.lastUpdate
-                  ? `#${c.lastUpdate.recordId} (${new Date(c.lastUpdate.occurredAt).toLocaleString()})`
-                  : '—'}
-              </td>
-              <td>
-                {c.lastPublish
-                  ? `${c.lastPublish.action} #${c.lastPublish.recordId} (${new Date(
-                      c.lastPublish.occurredAt
-                    ).toLocaleString()})`
-                  : '—'}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <div className={s.layout}>
+        <div>
+          <table className={s.table}>
+            <thead>
+              <tr>
+                <th>Role</th>
+                <th>Name</th>
+                <th>Last login</th>
+              </tr>
+            </thead>
+            <tbody>
+              {collaborators.map((c) => (
+                <tr key={c.id}>
+                  <td>{c.role}</td>
+                  <td>{c.name}</td>
+                  <td>{c.lastAccess ? new Date(c.lastAccess).toLocaleString() : 'Never'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <div className={s.activities}>
+          <div className={s.column}>
+            <h3>Last updated records</h3>
+            <ul className={s.list}>
+              {recentUpdates.map((u) => (
+                <li key={`${u.recordId}-${u.occurredAt}`}>
+                  #{u.recordId} ({new Date(u.occurredAt).toLocaleString()})
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className={s.column}>
+            <h3>Last publish/unpublish</h3>
+            <ul className={s.list}>
+              {recentPublishes.map((p) => (
+                <li key={`${p.recordId}-${p.occurredAt}`}>
+                  {p.action} #{p.recordId} ({new Date(p.occurredAt).toLocaleString()})
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
     </Canvas>
   );
 }

--- a/src/entrypoints/styles.module.css
+++ b/src/entrypoints/styles.module.css
@@ -11,3 +11,20 @@
   padding: var(--spacing-s);
   border-bottom: 1px solid var(--light-borders-color);
 }
+.layout {
+  display: flex;
+  gap: var(--spacing-l);
+  align-items: flex-start;
+}
+.activities {
+  display: flex;
+  gap: var(--spacing-l);
+}
+.column {
+  flex: 1;
+}
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}


### PR DESCRIPTION
## Summary
- capture recent updates and publishes using item list queries
- show collaborator list separately from recent activity
- style the new layout with flex columns

## Testing
- `npm run build`
